### PR TITLE
only make copy when censor is detected.

### DIFF
--- a/scripts/nudenet_ext.py
+++ b/scripts/nudenet_ext.py
@@ -35,7 +35,7 @@ def process(p: processing.StableDiffusionProcessing=None, pp: scripts.Postproces
     if nudenet.detector is None:
         nudenet.detector = nudenet.NudeDetector(providers=['CUDAExecutionProvider', 'CPUExecutionProvider']) # loads and initializes model once
     nudes = nudenet.detector.censor(image=pp.image, method=method, min_score=score, censor=censor, blocks=blocks, overlay=overlay)
-    if len(censor) > 0: # replace image if anything is censored
+    if len(nudes.censored) > 0:  # Check if there are any censored areas
         if not copy:
             pp.image = nudes.output
         else:


### PR DESCRIPTION
generate copy on if censorship occurs instead of on detection of a censor.

reasoning: when any of the potential censors were detected it was generating a copy of the image even when nothing was censored. 